### PR TITLE
[12] Use source language text as result instead of make a request to translate it

### DIFF
--- a/controllers/translateController.js
+++ b/controllers/translateController.js
@@ -1,4 +1,4 @@
-const { translate } = require('@vitalets/google-translate-api');
+const { translate } = require('../services/translateService');
 const { getOrCreateJsonFile } = require('../utils/getOrCreateJsonFile');
 const fs = require('fs');
 const { parsePath } = require('../utils/getConfigPath');
@@ -17,7 +17,7 @@ const translateController = async (text, sourceLanguage, nameOfTranslation, opti
   const { languages, basePath } = require(settingsFilePath); 
   
   for await (const language of languages) {
-    const { text: result } = await translate(text, { from: sourceLanguage, to: language.name });
+    const { text: result } = await translate(text, sourceLanguage, language.name);
 
     language.files.forEach(fileName => {
       const { file: languageJson, parsedPath } = getOrCreateJsonFile(basePath, fileName);

--- a/controllers/translateController.test.js
+++ b/controllers/translateController.test.js
@@ -20,12 +20,15 @@ describe("TranslateController", () => {
         }
     })
 
-    it("It's calling translate function for each language on config path", async () => {
+    it("It's calling translate function for each language on config path except for the source language", async () => {
         const { languages } = config;
 
         await translateController(text, sourceLanguage, nameOfTranslation, { settingsFile: configPath });
 
-        expect(translate).toHaveBeenCalledTimes(languages.length);
+        const isSourceLanguage = languages.some(language => language.name === sourceLanguage);
+        const timesToBeCalled = isSourceLanguage ? languages.length - 1 : languages.length;
+
+        expect(translate).toHaveBeenCalledTimes(timesToBeCalled);
     });
 
     it("It's throwing an error if no config file is found", async () => {
@@ -37,9 +40,15 @@ describe("TranslateController", () => {
             basePath: "test-configs/translations",
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        "en.json",
+                        "es.json",
+                    ]
+                },
+                {
+                    name: 'fr',
+                    files: [
+                        "fr.json",
                     ]
                 }
             ]
@@ -51,7 +60,7 @@ describe("TranslateController", () => {
 
         await translateController(text, sourceLanguage, nameOfTranslation, { settingsFile: 'test-configs/custom-config.json' });
 
-        expect(translate).toHaveBeenCalledTimes(1); 
+        expect(translate).toHaveBeenCalledTimes(2); 
     });
 
     it("It's throwing an error if no languages are found on config file", async () => {
@@ -83,9 +92,9 @@ describe("TranslateController", () => {
             basePath: 'test-configs/translations',
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        'en.json',
+                        'es.json',
                     ]
                 }
             ]
@@ -109,9 +118,9 @@ describe("TranslateController", () => {
             basePath: 'test-configs/translations',
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        'en.json',
+                        'es.json',
                     ]
                 }
             ]
@@ -135,9 +144,9 @@ describe("TranslateController", () => {
             basePath: 'test-configs/translations',
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        'en.json',
+                        'es.json',
                     ]
                 }
             ]
@@ -161,9 +170,9 @@ describe("TranslateController", () => {
             basePath: 'test-configs/translations',
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        'en.json',
+                        'es.json',
                     ]
                 }
             ]
@@ -190,9 +199,9 @@ describe("TranslateController", () => {
             basePath: 'test-configs/translations',
             languages: [
                 {
-                    name: 'en',
+                    name: 'es',
                     files: [
-                        'en.json',
+                        'es.json',
                     ]
                 }
             ]

--- a/services/translateService.js
+++ b/services/translateService.js
@@ -1,0 +1,17 @@
+const { translate: googleTranslate } = require('@vitalets/google-translate-api');
+
+const translateEngines = {
+    google: googleTranslate
+}
+
+const validEngines = Object.keys(translateEngines).join(', ');
+
+const translate = async (text, from, to, engine = 'google') => {
+    if (!translateEngines[engine]) throw new Error(`Invalid engine. Try with one of these: ${validEngines}`);
+    
+    if (from === to) return { text };
+
+    return await translateEngines[engine](text, { from, to });
+}
+
+module.exports = { translate, validEngines };

--- a/services/translateService.test.js
+++ b/services/translateService.test.js
@@ -1,0 +1,33 @@
+const { translate: googleTranslate } = require('@vitalets/google-translate-api');
+const { translate, validEngines } = require('./translateService');
+
+describe('translate', () => {
+  let text, from, to;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    text = 'Hello world!';
+    from = 'en';
+    to = 'es';
+  });
+
+  it('should translate text from English to Spanish using Google Translate', async () => {
+    const result = await translate(text, from, to);
+
+    expect(googleTranslate).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe(`Hello world! translated from ${from} to ${to}`);
+  });
+
+  it('should return the same text if from and to languages are the same', async () => {
+    to = 'en';
+
+    const result = await translate(text, from, to);
+    expect(googleTranslate).toHaveBeenCalledTimes(0);
+    expect(result.text).toBe(text);
+  });
+
+  it('should throw an error if an invalid engine is provided', async () => {
+    const engine = 'invalid';
+    await expect(translate(text, from, to, engine)).rejects.toThrow(`Invalid engine. Try with one of these: ${validEngines}`);
+  });
+});


### PR DESCRIPTION
## Explanation

If we want to translate a text "Hello world" from english to our language list array, and on our languages list is "english", so we are using the same text provided "Hello world" instead of translate it from "en" to "en", which doesn't makes sense.

Added some tests to validate that this is working as expected.

Also prepared a bit the way to include more translator engines to the library

fixes #12 