### PR TITLE
Fixed npm published verison bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-translate-generator",
-  "version": "1.0.3",
+  "version": "1.0.31",
   "description": "A small NodeJS tool that generates translations for i18n and put them on their appropriate files",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "files": [
     "config.js",
     "cli.js",
-    "SUPPORTED-LANGUAGE.json",
+    "ALL-LANGUAGES-CODES.json",
     "utils/getConfigPath.js",
     "utils/getOrCreateJsonFile.js",
     "utils/getTranslationEnginePreferences.js",


### PR DESCRIPTION
NPM Published version was not working because ALL-LANGUAGES-CODES file was missed on the files package json array

https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files

Maybe in a future issue we need to improve the files array to use glob pattern instead

fixes #39  