### PR TITLE
Updated tests to make them work as if was installed from npm published package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,14 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Create package to simulate it is installed from npm
+        run: npm pack
+
+      - name: Unzip package
+        run: tar -xzf i18n-translate-generator-*.tgz
+
+      - name: Moves into package folder
+        run: cd package
+
       - name: Run Tests
         run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "i18n-translate-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "i18n-translate-generator",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "@vitalets/google-translate-api": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-translate-generator",
-  "version": "1.0.31",
+  "version": "1.0.4",
   "description": "A small NodeJS tool that generates translations for i18n and put them on their appropriate files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was having problems to test the program as if was a published NPM package, since it is a bit different from local package.

In order to fix this ,I added to the tests steps the steps to package the Node program and then run the tests as if it was the program that will see the final client.

So we can avoid errors when publishing on NPM a package that only have been tested locally

---

This PR also points to be a Release for the 1.0.4 version which includes the new INIT command